### PR TITLE
Handle video element errors in getThumbnails()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "video-metadata-thumbnails",
-  "version": "1.0.7",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -208,10 +208,25 @@ export class Video {
         this.videoElement.removeEventListener('ended', endedHandler, false);
         this.videoElement.removeEventListener('canplaythrough', canplayHandler, false);
         this.videoElement.removeEventListener('timeupdate', timeupdateHandler, false);
+        this.videoElement.removeEventListener('error', errorHandler, false);
+      };
+      const errorHandler = () => {
+        const { error } = this.videoElement;
+        if (error) {
+          reject(new Error(`__NAME__ error ${error.code}; details: ${error.message}`));
+        } else {
+          reject(new Error('__NAME__ unknown error'));
+        }
+        this.videoElement.removeEventListener('progress', progressHandler, false);
+        this.videoElement.removeEventListener('ended', endedHandler, false);
+        this.videoElement.removeEventListener('canplaythrough', canplayHandler, false);
+        this.videoElement.removeEventListener('timeupdate', timeupdateHandler, false);
+        this.videoElement.removeEventListener('error', errorHandler, false);
       };
       this.videoElement.addEventListener('canplaythrough', canplayHandler, false);
       this.videoElement.addEventListener('timeupdate', timeupdateHandler, false);
       this.videoElement.addEventListener('ended', endedHandler, false);
+      this.videoElement.addEventListener('error', errorHandler, false);
     });
   }
 


### PR DESCRIPTION
Currently if you try to get thumbnails for the video that is not supported by browser (e.g. Chrome and video that is encoded by mpeg2video codec), the `await getThumbnails()` call becomes stuck because it neither resolves nor rejects the returning promise.

The pull request adds the same error handler as in `getMetadata()` method.