### PR TITLE
Fix thumbnail generation for CORS-enabled videos

### DIFF
--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -73,6 +73,7 @@ export class Video {
     this.videoElement.preload = 'metadata';
     this.videoElement.muted = true;
     this.videoElement.volume = 0;
+    this.videoElement.crossOrigin = 'anonymous';
 
     // 初始化canvas
     const canvas: HTMLCanvasElement = document.createElement('canvas') as HTMLCanvasElement;


### PR DESCRIPTION
Currently if you try to generate thumbnail for the video source URL with enabled CORS (video served with `Access-Control-Allow-Origin: *` header), you'll get error `Failed to execute 'toBlob' on 'HTMLCanvasElement': Tainted canvases may not be exported.`

The pull request fixes thumbnail generation for CORS-enabled videos.